### PR TITLE
Address TRAC-555

### DIFF
--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -78,7 +78,7 @@
   <!--
     this template adds a mods:recordInfo element to the file if the element is not present
    -->
-  <xsl:template match="mods:physicalDescription[mods:note[@displayLabel='Publication Status']]">
+  <xsl:template match="mods:originInfo[mods:dateIssued[@keyDate='yes']]">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -50,12 +50,27 @@
     </xsl:copy>
   </xsl:template>
 
+  <!--
+    copy the initial values in mods:originInfo. test for a mods:dateCreated element and,
+    if it doesn't exist create mods:dateCreated.
+  -->
   <xsl:template match="mods:originInfo">
     <xsl:copy>
-      <mods:dateCreated encoding="w3cdtf">
-        <xsl:value-of select="$date-in"/>
-      </mods:dateCreated>
+      <xsl:if test="not(mods:dateCreated[@encoding='w3cdtf'])">
+        <mods:dateCreated encoding="w3cdtf">
+          <xsl:value-of select="$date-in"/>
+        </mods:dateCreated>
+      </xsl:if>
       <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!--
+    *if* there is a mods:originInfo/mods:dateCreated, update the value.
+  -->
+  <xsl:template match="mods:originInfo/mods:dateCreated[@encoding='w3cdtf']">
+    <xsl:copy>
+      <xsl:value-of select="$date-in"/>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -78,7 +78,7 @@
   <!--
     this template adds a mods:recordInfo element to the file if the element is not present
    -->
-  <xsl:template match="mods:physicalDescription[@authority='local']">
+  <xsl:template match="mods:physicalDescription[mods:note[@displayLabel='Publication Status']]">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -61,7 +61,7 @@
           <xsl:value-of select="$date-in"/>
         </mods:dateCreated>
       </xsl:if>
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
 
@@ -70,6 +70,7 @@
   -->
   <xsl:template match="mods:originInfo/mods:dateCreated[@encoding='w3cdtf']">
     <xsl:copy>
+      <xsl:apply-templates select="@*"/>
       <xsl:value-of select="$date-in"/>
     </xsl:copy>
   </xsl:template>

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -73,4 +73,21 @@
       <xsl:value-of select="$date-in"/>
     </xsl:copy>
   </xsl:template>
+
+  <!--
+    add-recordInfo adds the initial mods:recordInfo element and children to a new record.
+   -->
+  <xsl:template match="mods:physicalDescription[@authority='local']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+    <mods:recordInfo displayLabel="Submission">
+      <mods:recordCreationDate encoding="w3cdtf">
+        <xsl:value-of select="$date-in"/>
+      </mods:recordCreationDate>
+      <mods:recordChangeDate keyDate="yes" encoding="w3cdtf">
+        <xsl:value-of select="$date-in"/>
+      </mods:recordChangeDate>
+    </mods:recordInfo>
+  </xsl:template>
 </xsl:stylesheet>

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -75,19 +75,33 @@
   </xsl:template>
 
   <!--
-    add-recordInfo adds the initial mods:recordInfo element and children to a new record.
+    this template adds a mods:recordInfo element to the file if the element is not present
    -->
   <xsl:template match="mods:physicalDescription[@authority='local']">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
-    <mods:recordInfo displayLabel="Submission">
-      <mods:recordCreationDate encoding="w3cdtf">
-        <xsl:value-of select="$date-in"/>
-      </mods:recordCreationDate>
-      <mods:recordChangeDate keyDate="yes" encoding="w3cdtf">
-        <xsl:value-of select="$date-in"/>
-      </mods:recordChangeDate>
-    </mods:recordInfo>
+    <xsl:if test="not(following-sibling::mods:recordInfo[@displayLabel='Submission'])">
+      <mods:recordInfo displayLabel="Submission">
+        <mods:recordCreationDate encoding="w3cdtf">
+          <xsl:value-of select="$date-in"/>
+        </mods:recordCreationDate>
+        <mods:recordChangeDate keyDate="yes" encoding="w3cdtf">
+          <xsl:value-of select="$date-in"/>
+        </mods:recordChangeDate>
+      </mods:recordInfo>
+    </xsl:if>
+  </xsl:template>
+
+  <!--
+    this template updates the mods:recordInfo element with a new mods:recordDateChange for each edit of the MODS datastream
+  -->
+  <xsl:template match="mods:recordInfo[@displayLabel='Submission']/mods:recordChangeDate[@keyDate='yes'][@encoding='w3cdtf'][position() = last()]">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+    <mods:recordChangeDate keyDate="yes" encoding="w3cdtf">
+      <xsl:value-of select="$date-in"/>
+    </mods:recordChangeDate>
   </xsl:template>
 </xsl:stylesheet>

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -53,6 +53,8 @@
   <!--
     copy the initial values in mods:originInfo. test for a mods:dateCreated element and,
     if it doesn't exist create mods:dateCreated.
+    existential test for mods:recordInfo[@displayLabel='submission']; if the following-sibling
+    does not exist, create it.
   -->
   <xsl:template match="mods:originInfo">
     <xsl:copy>
@@ -61,25 +63,6 @@
           <xsl:value-of select="$date-in"/>
         </mods:dateCreated>
       </xsl:if>
-      <xsl:apply-templates select="@*|node()"/>
-    </xsl:copy>
-  </xsl:template>
-
-  <!--
-    *if* there is a mods:originInfo/mods:dateCreated, update the value.
-  -->
-  <xsl:template match="mods:originInfo/mods:dateCreated[@encoding='w3cdtf']">
-    <xsl:copy>
-      <xsl:apply-templates select="@*"/>
-      <xsl:value-of select="$date-in"/>
-    </xsl:copy>
-  </xsl:template>
-
-  <!--
-    this template adds a mods:recordInfo element to the file if the element is not present
-   -->
-  <xsl:template match="mods:originInfo[mods:dateIssued[@keyDate='yes']]">
-    <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
     <xsl:if test="not(following-sibling::mods:recordInfo[@displayLabel='Submission'])">
@@ -92,6 +75,16 @@
         </mods:recordChangeDate>
       </mods:recordInfo>
     </xsl:if>
+  </xsl:template>
+
+  <!--
+    *if* there is a mods:originInfo/mods:dateCreated, update the value.
+  -->
+  <xsl:template match="mods:originInfo/mods:dateCreated[@encoding='w3cdtf']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:value-of select="$date-in"/>
+    </xsl:copy>
   </xsl:template>
 
   <!--

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -11,6 +11,8 @@
   <xsl:output encoding="UTF-8" indent="yes" method="xml"/>
   <xsl:strip-space elements="*"/>
 
+  <xsl:param name="date-in" select="''"/>
+
   <!-- identity transform -->
   <xsl:template match="@*|node()">
     <xsl:copy>
@@ -48,4 +50,12 @@
     </xsl:copy>
   </xsl:template>
 
+  <xsl:template match="mods:originInfo">
+    <xsl:copy>
+      <mods:dateCreated encoding="w3cdtf">
+        <xsl:value-of select="$date-in"/>
+      </mods:dateCreated>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-555](https://jira.lib.utk.edu/browse/TRAC-555)

# What does this Pull Request do?
This PR updates the UTK_ir_etds_post_process stylesheet to programmatically add mods:recordInfo[@displayLabel='Submission'] as well as programmatically update a child element of same to reflect changes to the MODS datastream by an end user. Additionally, it addresses mods:originInfo and updates the children and their values appropriately.

We need to add submission information to different elements in the MODS datastream. This PR addresses those needs.

# What's new?
1) template rules for mods:originInfo
1a) add a mods:dateCreated on initial datastream creation
1b) on subsequent modifications to the datastream, update the value of mods:dateCreated
2) template rules for mods:recordInfo[@displayLabel='Submission']
2a) conditionally check for mods:recordInfo..., if not present then create the element and children with appropriate values
2b) on subsequent modifications to the datastream, update the value of mods:recordChangeDate to reflect the date/time of the changes.

# How should this be tested?
* acquire my repo and branch and place it in the sanctuary of your freshly destroyed and rebuilt TRACE vm
* `sudo cp the-path-to-my-repo/post_process_transforms/UTK_ir_etds_post_process.xsl /var/www/drupal/sites/all/modules/islandora_xml_forms/builder/self_transforms/`
* **verify** that the *Thesis MODS Form* has an **self-transform** association linking it to the UTK_ir_etds_post_process stylesheet.
* Create a new record in the GUI with the standard MODS template; i.e. Thesis MODS Form.
* Review the output to verify that the following XPaths are populated with w3cdtf-lookin' date values:
  * mods:originInfo/mods:dateCreated[@encoding='w3cdtf'] (= '2017-01-21T21:05:52-5:00'; e.g.)
  * mods:recordInfo[@displayLabel='Submission']/mods:recordCreationDate[@encoding='w3cdtf'] (= '2017-01-21T20:55:32-5:00'; e.g.)
  * mods:recordInfo[@displayLabel='Submission']/mods:recordChangeDate[@keyDate='yes'][@encoding='w3cdtf']
    * this element/XPath is repeatable!
* Note any problems with these XPaths and continue!
* 'Edit' the MODS datastream, using the same form, and repeat the XPath checks.
  * mods:dateCreated should reflect the time of the **most recent change!**
  * mods:recordCreationDate should reflect the time of the **initial submission *not* subsequent edits!**
  * mods:recordDateChange should repeat from where-ever to there-ever, reflecting the times the MODS datastream was manipulated via the form!

1. Option 1:
	* Import the Form
	* Associate it with a content model
	* Apply any additional / related transforms
	* Create a new record and select the newly associated form
	* Edit that record to see if the form still behaves correctly
2. Option 2:
	* vagrant destroy
	* vagrant up

# Interested parties
@markpbaggett @DonRichards @pc37utn @cdeaneGit @robert-patrick-waltz 