### PR TITLE
Address TRAC-772 and update lcgft element.

### DIFF
--- a/xml_forms/UTK_ir_etds.xml
+++ b/xml_forms/UTK_ir_etds.xml
@@ -1244,7 +1244,7 @@
         </properties>
         <children/>
       </element>
-      <element name="genre">
+      <element name="genreLCGFT">
         <properties>
           <type>hidden</type>
           <access>TRUE</access>
@@ -1268,7 +1268,7 @@
               <value>&lt;genre authority="lcgft" valueURI="http://id.loc.gov/authorities/genreForms/gf2014026039"&gt;Academic theses&lt;/genre&gt;</value>
             </create>
             <read>
-              <path>mods:genre</path>
+              <path>mods:genre[@authority="lcgft"]</path>
               <context>parent</context>
             </read>
             <update>
@@ -1280,6 +1280,42 @@
         </properties>
         <children/>
       </element>
+      <element name="genreCOAR">
+        <properties>
+          <type>hidden</type>
+          <access>TRUE</access>
+          <autocomplete_path>islandora_autocomplete/islandora:citationCModel/mods.genre</autocomplete_path>
+          <collapsed>FALSE</collapsed>
+          <collapsible>FALSE</collapsible>
+          <disabled>FALSE</disabled>
+          <executes_submit_callback>FALSE</executes_submit_callback>
+          <multiple>FALSE</multiple>
+          <required>FALSE</required>
+          <resizable>FALSE</resizable>
+          <title>Genre</title>
+          <tree>TRUE</tree>
+          <actions>
+            <create>
+              <path>self::node()</path>
+              <context>parent</context>
+              <schema/>
+              <type>xml</type>
+              <prefix>NULL</prefix>
+              <value>&lt;genre authority="COAR" valueURI="http://purl.org/coar/resource_type/c_46ec"&gt;thesis&lt;/genre&gt;</value>
+            </create>
+            <read>
+              <path>mods:genre[@authority="COAR"]</path>
+              <context>parent</context>
+            </read>
+            <update>
+              <path>self::node()</path>
+              <context>self</context>
+            </update>
+            <delete>NULL</delete>
+          </actions>
+        </properties>
+        <children/>
+      </element>     
       <element name="language">
         <properties>
           <type>hidden</type>


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-772](https://jira.lib.utk.edu/browse/TRAC-772)

# What does this Pull Request do?

Implements COAR authority for genre.

# What's new?

Adds a second genre authority that reflects COAR via the Drupal Form API and Form Builder. Updates the previous so that values from one another are not accidentally inserted into the wrong node.

# How should this be tested?

* Test:
    * Import the Form with Form Builder
    * Associate it with a content model
    * Apply the related post process transform (it starts with UTK_ir as well)
    * Create a new record and select the newly associated form
    * Edit that record to verify proper CRUD behavior

# Additional Notes:
This should only add some hidden stuff in the background, but with form builder it's always good to test the whole process.

**NOTE**: this will not work on the test content in TRACE already.

There is a second p.r. open that touches the same file.  I assume there should not be a conflict, but it's possible.

# Interested parties
@DonRichards @CanOfBees @robert-patrick-waltz @pc37utn @cdeaneGit 