### PR TITLE
Address DR-26.

### DIFF
--- a/xml_forms/roth_metadata_form.xml
+++ b/xml_forms/roth_metadata_form.xml
@@ -94,7 +94,7 @@
       </element>
       <element name="titleInfo">
         <properties>
-          <type>tabs</type>
+          <type>markup</type>
           <access>TRUE</access>
           <collapsed>FALSE</collapsed>
           <collapsible>FALSE</collapsible>
@@ -104,75 +104,127 @@
           <required>FALSE</required>
           <resizable>FALSE</resizable>
           <tree>TRUE</tree>
+          <actions>
+            <create>
+              <path>self::node()</path>
+              <context>parent</context>
+              <schema/>
+              <type>xml</type>
+              <prefix>NULL</prefix>
+              <value>&lt;titleInfo&gt;&lt;/titleInfo&gt;</value>
+            </create>
+            <read>
+              <path>mods:titleInfo[not(@supplied)]</path>
+              <context>parent</context>
+            </read>
+            <update>NULL</update>
+            <delete>NULL</delete>
+          </actions>
         </properties>
         <children>
-          <element name="0">
+          <element name="title">
             <properties>
-              <type>tabpanel</type>
+              <type>textarea</type>
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <disabled>FALSE</disabled>
+              <description>This is the title from the finding aid.</description>
+              <disabled>TRUE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
               <multiple>FALSE</multiple>
-              <required>FALSE</required>
+              <required>TRUE</required>
               <resizable>FALSE</resizable>
+              <title>Title from Finding Aid</title>
               <tree>TRUE</tree>
               <actions>
                 <create>
                   <path>self::node()</path>
                   <context>parent</context>
                   <schema/>
-                  <type>element</type>
+                  <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>titleInfo</value>
+                  <value>&lt;title&gt;%value%&lt;/title&gt;</value>
                 </create>
                 <read>
-                  <path>mods:titleInfo</path>
+                  <path>mods:title</path>
                   <context>parent</context>
                 </read>
-                <update>NULL</update>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
                 <delete>NULL</delete>
               </actions>
             </properties>
-            <children>
-              <element name="Title">
-                <properties>
-                  <type>textarea</type>
-                  <access>TRUE</access>
-                  <collapsed>FALSE</collapsed>
-                  <collapsible>FALSE</collapsible>
-                  <description>Press "Add" to add another title.</description>
-                  <disabled>FALSE</disabled>
-                  <executes_submit_callback>FALSE</executes_submit_callback>
-                  <multiple>FALSE</multiple>
-                  <required>FALSE</required>
-                  <resizable>FALSE</resizable>
-                  <title>Title</title>
-                  <tree>TRUE</tree>
-                  <actions>
-                    <create>
-                      <path>self::node()</path>
-                      <context>parent</context>
-                      <schema/>
-                      <type>element</type>
-                      <prefix>NULL</prefix>
-                      <value>title</value>
-                    </create>
-                    <read>
-                      <path>mods:title</path>
-                      <context>parent</context>
-                    </read>
-                    <update>
-                      <path>self::node()</path>
-                      <context>self</context>
-                    </update>
-                    <delete>NULL</delete>
-                  </actions>
-                </properties>
-                <children/>
-              </element>
-            </children>
+            <children/>
+          </element>
+        </children>
+      </element>
+      <element name="titleInfosupplied">
+        <properties>
+          <type>markup</type>
+          <access>TRUE</access>
+          <collapsed>FALSE</collapsed>
+          <collapsible>FALSE</collapsible>
+          <disabled>FALSE</disabled>
+          <executes_submit_callback>FALSE</executes_submit_callback>
+          <multiple>FALSE</multiple>
+          <required>FALSE</required>
+          <resizable>FALSE</resizable>
+          <tree>TRUE</tree>
+          <actions>
+            <create>
+              <path>self::node()</path>
+              <context>parent</context>
+              <schema/>
+              <type>xml</type>
+              <prefix>NULL</prefix>
+              <value>&lt;titleInfo supplied="yes"&gt;&lt;/titleInfo&gt;</value>
+            </create>
+            <read>
+              <path>mods:titleInfo[@supplied="yes"]</path>
+              <context>parent</context>
+            </read>
+            <update>NULL</update>
+            <delete>NULL</delete>
+          </actions>
+        </properties>
+        <children>
+          <element name="title">
+            <properties>
+              <type>textarea</type>
+              <access>TRUE</access>
+              <collapsed>FALSE</collapsed>
+              <collapsible>FALSE</collapsible>
+              <description>This is the title supplied by the curators.</description>
+              <disabled>FALSE</disabled>
+              <executes_submit_callback>FALSE</executes_submit_callback>
+              <multiple>FALSE</multiple>
+              <required>TRUE</required>
+              <resizable>FALSE</resizable>
+              <title>Supplied Title</title>
+              <tree>TRUE</tree>
+              <actions>
+                <create>
+                  <path>self::node()</path>
+                  <context>parent</context>
+                  <schema/>
+                  <type>xml</type>
+                  <prefix>NULL</prefix>
+                  <value>&lt;title&gt;%value%&lt;/title&gt;</value>
+                </create>
+                <read>
+                  <path>mods:title</path>
+                  <context>parent</context>
+                </read>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
+                <delete>NULL</delete>
+              </actions>
+            </properties>
+            <children/>
           </element>
         </children>
       </element>


### PR DESCRIPTION
**JIRA Ticket**: [DR-26](https://jira.lib.utk.edu/browse/DR-26)

# What does this Pull Request do?

This pull request makes it so curators can add supplied titles and not change the title from the finding aid.

# What's new?

Form elements have been modified so that:

1. Only titles without a supplied attribute are loaded to the Title from Finding Aid form element.
2. Titles from the Finding Aid can not be changed.
3. A new box for curator supplied titles have been added.

# How should this be tested?

Describe what steps to take to test this change.

* Test the entire workflow:
    * Import the Form
    * Associate it with a content model
    * Apply any additional related transforms
    * Create a new record and select the newly associated form
    * Edit that record to verify proper CRUD behavior

**MAKE SURE** that there are no conflicts between titles from the finding aid and titles from the curator.

Also, this should be tested with this metadata:

https://github.com/UTKcataloging/dutch_roth

# Additional Notes:
This is for the July sprint.

# Interested parties
@CanOfBees 