### PR TITLE
Address TRAC-844: drop "@type='personal'" from read on thesis advisor…

### DIFF
--- a/xml_forms/UTK_ir_etds.xml
+++ b/xml_forms/UTK_ir_etds.xml
@@ -872,7 +872,7 @@
                   <value>name</value>
                 </create>
                 <read>
-                  <path>mods:name[@type='personal']/mods:role[mods:roleTerm = 'Thesis advisor']/..</path>
+                  <path>mods:name/mods:role[mods:roleTerm = 'Thesis advisor']/..</path>
                   <context>parent</context>
                 </read>
                 <update>NULL</update>
@@ -914,36 +914,6 @@
                       <path>self::node()</path>
                       <context>self</context>
                     </update>
-                    <delete>NULL</delete>
-                  </actions>
-                </properties>
-                <children/>
-              </element>
-              <element name="nameType">
-                <properties>
-                  <type>hidden</type>
-                  <access>TRUE</access>
-                  <collapsed>FALSE</collapsed>
-                  <collapsible>FALSE</collapsible>
-                  <default_value>personal</default_value>
-                  <disabled>FALSE</disabled>
-                  <executes_submit_callback>FALSE</executes_submit_callback>
-                  <multiple>FALSE</multiple>
-                  <required>FALSE</required>
-                  <resizable>FALSE</resizable>
-                  <title>nameType</title>
-                  <tree>TRUE</tree>
-                  <actions>
-                    <create>
-                      <path>self::node()</path>
-                      <context>parent</context>
-                      <schema/>
-                      <type>attribute</type>
-                      <prefix>NULL</prefix>
-                      <value>type</value>
-                    </create>
-                    <read>NULL</read>
-                    <update>NULL</update>
                     <delete>NULL</delete>
                   </actions>
                 </properties>


### PR DESCRIPTION
…; drop nameType element.

**JIRA Ticket**: [TRAC-844](https://jira.lib.utk.edu/browse/TRAC-844)

# What does this Pull Request do?
This PR updates the MODS XML form to correctly enable the display of multiple thesis advisors during a 'read' (or *edit*) action.

# What's new?
Dropped 'type="personal"' from the read instructions for the thesis advisor template. Additionally, dropped the nameType instruction.

# How should this be tested?

    * clone this repository and
    * Import the Form
    * Associate it with a content model
    * Apply any additional related transforms
    * Create a new record and select the newly associated form
    * Edit that record to verify proper CRUD behavior

# Interested parties
@markpbaggett @DonRichards @robert-patrick-waltz @pc37utn @cdeaneGit 