### PR TITLE
Update form to auto assign subject geographic heading.

### DIFF
--- a/xml_forms/roth_metadata_form.xml
+++ b/xml_forms/roth_metadata_form.xml
@@ -992,7 +992,7 @@ Please ensure that the descriptive information pertains to the digitized object 
                   <access>TRUE</access>
                   <collapsed>TRUE</collapsed>
                   <collapsible>TRUE</collapsible>
-                  <description>If not local, list authority. (e.g. LCNAF)</description>
+                  <description>If not local, list authority. (e.g. naf)</description>
                   <disabled>FALSE</disabled>
                   <executes_submit_callback>FALSE</executes_submit_callback>
                   <multiple>FALSE</multiple>
@@ -1151,7 +1151,7 @@ Please ensure that the descriptive information pertains to the digitized object 
                   <access>TRUE</access>
                   <collapsed>FALSE</collapsed>
                   <collapsible>FALSE</collapsible>
-                  <description>If not local, list authority. (e.g. LCNAF)</description>
+                  <description>If not local, list authority. (e.g. naf)</description>
                   <disabled>FALSE</disabled>
                   <executes_submit_callback>FALSE</executes_submit_callback>
                   <multiple>FALSE</multiple>
@@ -1310,7 +1310,7 @@ Please ensure that the descriptive information pertains to the digitized object 
                   <access>TRUE</access>
                   <collapsed>TRUE</collapsed>
                   <collapsible>TRUE</collapsible>
-                  <description>If not local, list authority. (e.g. LCSH)</description>
+                  <description>If not local, list authority. (e.g. lcsh)</description>
                   <disabled>FALSE</disabled>
                   <executes_submit_callback>FALSE</executes_submit_callback>
                   <multiple>FALSE</multiple>
@@ -1365,6 +1365,165 @@ Please ensure that the descriptive information pertains to the digitized object 
                     </create>
                     <read>
                       <path>mods:topic/@valueURI</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>self::node()</path>
+                      <context>self</context>
+                    </update>
+                    <delete>NULL</delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
+            </children>
+          </element>
+        </children>
+      </element>
+      <element name="geographicSubjectDefault">
+        <properties>
+          <type>tabs</type>
+          <access>TRUE</access>
+          <collapsed>FALSE</collapsed>
+          <collapsible>FALSE</collapsible>
+          <disabled>FALSE</disabled>
+          <executes_submit_callback>FALSE</executes_submit_callback>
+          <multiple>FALSE</multiple>
+          <required>FALSE</required>
+          <resizable>FALSE</resizable>
+          <tree>TRUE</tree>
+        </properties>
+        <children>
+          <element name="0">
+            <properties>
+              <type>tabpanel</type>
+              <access>TRUE</access>
+              <collapsed>FALSE</collapsed>
+              <collapsible>FALSE</collapsible>
+              <disabled>FALSE</disabled>
+              <executes_submit_callback>FALSE</executes_submit_callback>
+              <multiple>FALSE</multiple>
+              <required>FALSE</required>
+              <resizable>FALSE</resizable>
+              <tree>TRUE</tree>
+              <actions>
+                <create>
+                  <path>self::node()</path>
+                  <context>parent</context>
+                  <schema/>
+                  <type>element</type>
+                  <prefix>NULL</prefix>
+                  <value>subject</value>
+                </create>
+                <read>
+                  <path>mods:subject</path>
+                  <context>parent</context>
+                </read>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
+                <delete>NULL</delete>
+              </actions>
+            </properties>
+            <children>
+              <element name="subjectGeographic">
+                <properties>
+                  <type>textfield</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <default_value>Great Smoky Mountains National Park (N.C. and Tenn.)</default_value>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <title>Default Geographic Subject</title>
+                  <tree>TRUE</tree>
+                  <actions>
+                    <create>
+                      <path>self::node()</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>element</type>
+                      <prefix>NULL</prefix>
+                      <value>geographic</value>
+                    </create>
+                    <read>
+                      <path>mods:geographic</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>self::node()</path>
+                      <context>self</context>
+                    </update>
+                    <delete>NULL</delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
+              <element name="authority">
+                <properties>
+                  <type>textfield</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <default_value>lcsh</default_value>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <title>Authority</title>
+                  <tree>TRUE</tree>
+                  <actions>
+                    <create>
+                      <path>self::node()</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>attribute</type>
+                      <prefix>NULL</prefix>
+                      <value>authority</value>
+                    </create>
+                    <read>
+                      <path>mods:geographic/@authority</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>self::node()</path>
+                      <context>self</context>
+                    </update>
+                    <delete>NULL</delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
+              <element name="valueURI">
+                <properties>
+                  <type>textfield</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <default_value>http://id.loc.gov/authorities/subjects/sh2005004887</default_value>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <title>Value URI</title>
+                  <tree>TRUE</tree>
+                  <actions>
+                    <create>
+                      <path>mods:geographic</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>attribute</type>
+                      <prefix>NULL</prefix>
+                      <value>valueURI</value>
+                    </create>
+                    <read>
+                      <path>mods:geographic/@valueURI</path>
                       <context>parent</context>
                     </read>
                     <update>


### PR DESCRIPTION
# What does this Pull Request do?

Anne and Ken would like to have the geographic subject heading "Great Smoky Mountains (N.C. and Tenn.)" (http://id.loc.gov/authorities/subjects/sh85057008) as a default heading for the collection. There are instances in which this default heading is not applicable (vacation to Florida photos, etc.), so there must be the opportunity for  Ken to remove it. 

# What's new?

I've added a separate subject geographic form element (geographicSubjectDefault) with the default values entered. I decided to do this rather than enter the default values in the existing subject geographic element (subjectGeographic) for efficiency. If the default values were added to the existing element, Ken would have to delete them every time he added a heading following the default heading.

Additionally, I've made slight changes to authority values ('naf' was incorrectly listed as 'lcnaf').

Example:
* Changes 'lcnaf' authority to 'naf'
* Added geographicSubjectDefault tab

# How should this be tested?

* Testing the entire workflow:
    * Import the Form
    * Associate it with a content model
    * Apply any additional related transforms
    * Create a new record and select the newly associated form
    * Edit that record to verify proper CRUD behavior

# Additional Notes:

WARNING: this is currently live on the server.

Example:
* Does this change require documentation to be updated? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Yes

# Interested parties
@markpbaggett @CanOfBees 