### PR TITLE
Address TRAC-887 by dropping COAR genre from form.

### DIFF
--- a/xml_forms/UTK_ir_etds.xml
+++ b/xml_forms/UTK_ir_etds.xml
@@ -1435,42 +1435,6 @@
         </properties>
         <children/>
       </element>
-      <element name="genreCOAR">
-        <properties>
-          <type>hidden</type>
-          <access>TRUE</access>
-          <autocomplete_path>islandora_autocomplete/islandora:citationCModel/mods.genre</autocomplete_path>
-          <collapsed>FALSE</collapsed>
-          <collapsible>FALSE</collapsible>
-          <disabled>FALSE</disabled>
-          <executes_submit_callback>FALSE</executes_submit_callback>
-          <multiple>FALSE</multiple>
-          <required>FALSE</required>
-          <resizable>FALSE</resizable>
-          <title>Genre</title>
-          <tree>TRUE</tree>
-          <actions>
-            <create>
-              <path>self::node()</path>
-              <context>parent</context>
-              <schema/>
-              <type>xml</type>
-              <prefix>NULL</prefix>
-              <value>&lt;genre authority="COAR" valueURI="http://purl.org/coar/resource_type/c_46ec"&gt;thesis&lt;/genre&gt;</value>
-            </create>
-            <read>
-              <path>mods:genre[@authority="COAR"]</path>
-              <context>parent</context>
-            </read>
-            <update>
-              <path>self::node()</path>
-              <context>self</context>
-            </update>
-            <delete>NULL</delete>
-          </actions>
-        </properties>
-        <children/>
-      </element>
       <element name="language">
         <properties>
           <type>hidden</type>


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-887](https://jira.lib.utk.edu/browse/TRAC-887)

# What does this Pull Request do?

Drops genre[@authority="COAR" term from begin written created, read, or updated with the form.

# What's new?
Because of requirements to split theses and dissertations in faceting, we need to further define a genre term for theses and dissertations.  We will use the COAR ontology and drop the previous genre term.

# How should this be tested?

* Testi the entire workflow:
    * Import the Form
    * Associate it with a content model
    * Apply any additional related transforms
    * Create a new record and select the newly associated form
    * Edit that record to verify proper CRUD behavior

# Additional Notes:
There are numerous related tickets that handle other aspects of this, but this is just to drop things related to this from the form.

# Interested parties
@CanOfBees 