### PR TITLE
address TRAC-941

### DIFF
--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -23,8 +23,17 @@
   </xsl:template>
 
   <!-- if any of the following elements are empty, drop them from the transform. this list could grow. -->
-  <!-- if an extra thesis advisor or committee member is added to the form -->
-  <xsl:template match="mods:name[@type='personal'][mods:displayForm='']"/>
+  <!--
+    if a thesis advisor or committee member is added via the form without a namePart[@type='given' AND 'family'] AND
+    has a role/roleTerm='Thesis advisor' or 'Committee member'.
+    MODS added via the form automatically gets an empty mods:displayForm.
+  -->
+  <xsl:template match="mods:name[mods:displayForm='']
+                                [mods:namePart[@type='given']='']
+                                [mods:namePart[@type='family']='']
+                                [mods:role/mods:roleTerm='Thesis advisor' or mods:role/roleTerm='Committee member']"/>
+  <!-- if there are any empty 'type' attributes (@type), ignore them -->
+  <xsl:template match="@type[.='']"/>
   <!-- if no supplemental files are attached in the initial form -->
   <xsl:template match="mods:relatedItem[@type='constituent'][mods:titleInfo[mods:title='']][mods:abstract='']"/>
   <!-- if no namePart[@type='termsOfAddress'] is present, drop the empty element -->

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -31,7 +31,7 @@
   <xsl:template match="mods:name[mods:displayForm='']
                                 [mods:namePart[@type='given']='']
                                 [mods:namePart[@type='family']='']
-                                [mods:role/mods:roleTerm='Thesis advisor' or mods:role/roleTerm='Committee member']"/>
+                                [mods:role/mods:roleTerm='Thesis advisor' or mods:role/mods:roleTerm='Committee member']"/>
   <!-- if there are any empty 'type' attributes (@type), ignore them -->
   <xsl:template match="@type[.='']"/>
   <!-- if no supplemental files are attached in the initial form -->

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -32,7 +32,7 @@
                                 [mods:namePart[@type='given']='' and mods:namePart[@type='family']='']
                                 [mods:role/mods:roleTerm='Thesis advisor' or mods:role/mods:roleTerm='Committee member']"/>
   <!--
-    if a thesis advisor or committee member is added but for some reason has a displayForm but not the namePart children,
+    if a thesis advisor or committee member is added but for some reason has a displayForm but not the following namePart siblings,
     delete the name node.
   -->
   <xsl:template match="mods:name[mods:displayForm='']

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -29,9 +29,15 @@
     MODS added via the form automatically gets an empty mods:displayForm.
   -->
   <xsl:template match="mods:name[mods:displayForm='']
-                                [mods:namePart[@type='given']='']
-                                [mods:namePart[@type='family']='']
+                                [mods:namePart[@type='given']='' and mods:namePart[@type='family']='']
                                 [mods:role/mods:roleTerm='Thesis advisor' or mods:role/mods:roleTerm='Committee member']"/>
+  <!--
+    if a thesis advisor or committee member is added but for some reason has a displayForm but not the namePart children,
+    delete the name node.
+  -->
+  <xsl:template match="mods:name[mods:displayForm='']
+                               [not(mods:namePart[@type='given']) and not(mods:namePart[@type='family'])]
+                               [mods:role/mods:roleTerm='Thesis advisor' or mods:role/mods:roleTerm='Committee member']"/>
   <!-- if there are any empty 'type' attributes (@type), ignore them -->
   <xsl:template match="@type[.='']"/>
   <!-- if no supplemental files are attached in the initial form -->


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-941](https://jira.lib.utk.edu/browse/TRAC-941)

# What does this Pull Request do?
Updates mods:name handling based on how child nodes are populated.

# What's new?
 Add a rule that will drop any mods:name that has an empty mods:namePart[@type='given' and 'family'], an empty mods:displayForm, and has a mods:role/mods:roleTerm = 'Thesis advisor' or 'Committee member'

# How should this be tested?
~~* Associate this post-processing transform
    * `vagrant destroy -f && vagrant up && vagrant ssh`
    * `git clone https://github.com/utkdigitalinitiatives/utk_isl_xml_forms`
    * `git checkout -b TRAC-941 origin/TRAC-941`
    * `sudo cp utk_isl_xml_forms/post_process_transforms/UTK_ir_etds_post_process.xsl /var/www/drupal/sites/all/modules/islandora_xml_forms/builder/self_transforms/UTK_ir_etds_post_process_941.xsl`
    * Associate the post-processing transform with the Thesis MODS Form.
        * As 'admin', use the Form Builder UI to first disable the current Thesis MODS associate and then associate this new post-process transform with the Form.
    * Pick your favorite PID and replace the MODS dsid [with this gist.](https://gist.github.com/CanOfBees/f80306ad9a2d2ef20a9c29b825724414)
    * Verify proper behavior from the post-processing transform; e.g. have empty the appropriate empty elements been dropped.~~

Edit: I wrote some incredibly poor testing instructions here. Thanks to @cdeaneGit for pointing out the problems.
### How This Should Be Considered For Testing ###
This PR presents a post-processing transform that will continue to work appropriately with data submitted through the Thesis MODS Form, so rather than testing the form submission process (you're welcome to do so, but that isn't a part of this PR) this transform should be considered as part of a separate process: will it (the stylesheet) serve to modify non-standard (and standard!) data in an external-to-Islandora transformation scenario.
* `vagrant up` and `vagrant ssh`
* Our VM doesn't have the `xsltproc` binary installed, so grab it with the following command: `sudo apt-get install xsltproc`
* Clone this repository to `/home/vagrant` and checkout the feature branch 
* cd to `utk_isl_xml_forms/`
* execute `curl -o test_data/941-test.xml https://gist.githubusercontent.com/CanOfBees/f80306ad9a2d2ef20a9c29b825724414/raw/a482fabc0604aa184941fc42e107c958413fbc25/test-mods.xml`
* execute `xsltproc -o 941-test-out.xml post_process_transforms/UTK_ir_etds_post_process.xsl test_data/941-test.xml`
* review the output to ensure validity and semantic correctness.

Alternately you can do most of that with oXygen on your desktop. You pick. :)
Apologies for bad testing instructions. Please let me know if you have questions.

## Note ##
If you try to use the test XML file in the form, it throws errors - as it should. 

## Interested Parties
@markpbaggett @cdeaneGit 