### PR TITLE
test BDS template changes for TRAC-865

### DIFF
--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -47,35 +47,96 @@
   <!-- if no namePart[@type='termsOfAddress'] is present, drop the empty element -->
   <xsl:template match="mods:name[@type='personal']/mods:namePart[@type='termsOfAddress'][.='']"/>
 
+  <!-- TEST BDS TEMPLATE CHANGES FOR TRAC-685 -->
+
+
+<xsl:template match="mods:name[@authority='orcid']">
+    <xsl:variable name="vID" select="@valueURI"/>
+    <xsl:variable name="vDigits" select="'0123456789'"/>
+
+    <xsl:choose>
+      <!-- ignore @valueURI when @valueURI is empty -->
+      <xsl:when test="$vID = ''">
+        <xsl:copy>
+          <xsl:apply-templates select="@type"/>
+          <xsl:apply-templates/>
+        </xsl:copy>
+      </xsl:when>
+      <!--
+        when @valueURI does not start with http AND matches (\d){4}-(\d){4}-(\d){4}-(\d){4}
+        create a new @valueURI and prepend 'http://test.net/' to the string
+      -->
+      <xsl:when test="not(starts-with($vID,'http://orcid.org'))
+                      and string-length(translate(substring($vID, 1, 4), $vDigits, '')) = 0
+                      and substring($vID, 5, 1) = '-'
+                      and string-length(translate(substring($vID, 6, 4), $vDigits, '')) = 0
+                      and substring($vID, 10, 1) = '-'
+                      and string-length(translate(substring($vID, 11, 4), $vDigits, '')) = 0
+                      and substring($vID, 15, 1) = '-'
+                      and string-length(translate(substring($vID, 16, 4), $vDigits, '')) = 0">
+        <xsl:copy>
+          <xsl:attribute name="valueURI">
+            <xsl:value-of select="concat('http://orcid.org/',$vID)"/>
+          </xsl:attribute>
+          <xsl:apply-templates select="@type"/>
+          <xsl:apply-templates select="@authority"/>
+          <xsl:apply-templates select="@authorityURI"/>
+          <xsl:apply-templates/>
+        </xsl:copy>
+      </xsl:when>
+      <!-- when @valueURI starts with http..., we're going to be assumptive and take the value -->
+      <xsl:when test="starts-with($vID,'http://orcid.org')">
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:when>
+      <!-- otherwise we'll assume that @valueURI and @test are irrelevant and we'll ignore them -->
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@type"/>
+          <xsl:apply-templates/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+  <!-- END TEST BDS TEMPLATE CHANGES FOR TRAC-685 -->
+
   <!-- *if* the valueURI is empty, copy the name element, but remove all attributes but @type='personal' -->
+  <!--
   <xsl:template match="mods:name[@authority='orcid'][@valueURI='']">
     <xsl:copy>
       <xsl:apply-templates select="@type"/>
       <xsl:apply-templates/>
     </xsl:copy>
   </xsl:template>
+  -->
 
   <!--
     *if* the @valueURI attached to mods:name[@authority='orcid'] is not
     empty AND does not start with 'http://orcid.org', process it separately
     in this template. this overrides the default identity transform.
   -->
+  <!--
   <xsl:template match="mods:name[@authority='orcid']/@valueURI[(not(.='')) and (not(starts-with(.,'http://orcid.org')))]">
     <xsl:attribute name="valueURI">
         <xsl:value-of select="concat('http://orcid.org/', .)"/>
     </xsl:attribute>
   </xsl:template>
+  -->
 
   <!--
     *if* the valueURI attached to mods:name[@authority='orcid'] is not empty
     AND starts with 'http://orcid.org', use the default template rules to copy
     the valueURI attribute.
   -->
+  <!--
   <xsl:template match="mods:name[@authority='orcid']/@valueURI[(not(.='')) and (starts-with(.,'http://orcid.org'))]">
     <xsl:copy>
       <xsl:apply-templates/>
     </xsl:copy>
   </xsl:template>
+  -->
 
   <!--
     processing affiliation elements. there will only ever be six:

--- a/post_process_transforms/UTK_ir_etds_post_process.xsl
+++ b/post_process_transforms/UTK_ir_etds_post_process.xsl
@@ -47,7 +47,6 @@
   <!-- if no namePart[@type='termsOfAddress'] is present, drop the empty element -->
   <xsl:template match="mods:name[@type='personal']/mods:namePart[@type='termsOfAddress'][.='']"/>
 
-  <!-- TEST BDS TEMPLATE CHANGES FOR TRAC-685 -->
 
 
 <xsl:template match="mods:name[@authority='orcid']">
@@ -100,43 +99,7 @@
     </xsl:choose>
 </xsl:template>
 
-  <!-- END TEST BDS TEMPLATE CHANGES FOR TRAC-685 -->
 
-  <!-- *if* the valueURI is empty, copy the name element, but remove all attributes but @type='personal' -->
-  <!--
-  <xsl:template match="mods:name[@authority='orcid'][@valueURI='']">
-    <xsl:copy>
-      <xsl:apply-templates select="@type"/>
-      <xsl:apply-templates/>
-    </xsl:copy>
-  </xsl:template>
-  -->
-
-  <!--
-    *if* the @valueURI attached to mods:name[@authority='orcid'] is not
-    empty AND does not start with 'http://orcid.org', process it separately
-    in this template. this overrides the default identity transform.
-  -->
-  <!--
-  <xsl:template match="mods:name[@authority='orcid']/@valueURI[(not(.='')) and (not(starts-with(.,'http://orcid.org')))]">
-    <xsl:attribute name="valueURI">
-        <xsl:value-of select="concat('http://orcid.org/', .)"/>
-    </xsl:attribute>
-  </xsl:template>
-  -->
-
-  <!--
-    *if* the valueURI attached to mods:name[@authority='orcid'] is not empty
-    AND starts with 'http://orcid.org', use the default template rules to copy
-    the valueURI attribute.
-  -->
-  <!--
-  <xsl:template match="mods:name[@authority='orcid']/@valueURI[(not(.='')) and (starts-with(.,'http://orcid.org'))]">
-    <xsl:copy>
-      <xsl:apply-templates/>
-    </xsl:copy>
-  </xsl:template>
-  -->
 
   <!--
     processing affiliation elements. there will only ever be six:


### PR DESCRIPTION
**JIRA Ticket**: [JIRA TRAC-685](https://jira.lib.utk.edu/browse/TRAC-685)
- add baseline ORCID validation to utk_ir_etds_post_process stylesheet


# What does this Pull Request do?
The format for an orcid is NNNN-NNNN-NNNN-NNNN.
 - The 'N' characters must be digits (integers).
 - The '-' characters must each be a single dash (a.k.a.  minus sign)
 - The file utk_isl_xml_forms/post_process_transforms/UTK_ir_etds_post_process.xsl has been revised to perform the orcid validation.

# What's new?
- Two files have been changed to develop and test this code.
  --utk_isl_xml_forms/post_process_transforms/UTK_ir_etds_post_process.xsl
 --TRACE/scripts/custom_scripts/100_upload_islandora_forms.sh
- The branch utk_isl_xml_forms(TRAC-685b-utk_isl_xml_forms) is the branch for the XSL file.
- The branch TRACE(TRAC-685-trace)  is the branch for the 100_upload...sh file.
- PULL LATEST VERSION of each branch.
- The branch TRACE(TRAC-685-trace) is NEVER MEANT to be merged, just used to make testing easier.
-  The file utk_isl_xml_forms/post_process_transforms/UTK_ir_etds_post_process.xsl hold the orcid validation code and is the subject of this pull request.
- The changes you should expect to see on testing are:
    -- A VALID orcid will appear in the mods file upon submission of the edt.  The generated mods name element will look like this:<pre><mods:name type="personal" authority="orcid" authorityURI="http://id.loc.gov/vocabulary/identifiers/orcid.html"  valueURI="http://orcid.org/0011-0022-0033-0044"></pre>
    -- An INVALID orcid will not appear in the mods file and the generated mods name element will look like this: <pre><mods:name type="personal"></pre>
    -- An empty value for orcid id will give the generated mods name element will look like this:<pre><mods:name type="personal"></pre>

# How should this be tested?
- <b>In a terminal</b>
 - Go to TRACE
 - Checkout branch TRAC-685-trace. pull latest version.
 - Do vagrant up on this branch and it will bring up utk_isl_xml_forms (TRAC-685b-utk_isl_xml_forms)
- <b>In a browser</b>
 - Go to http://localhost:8000/
 - Logon as userA
 - Submit several theses to Graduate Theses and Dissertations collection
    -- Enter a VALID orcid value such as 0011-0022-0033-0044
    -- Revise the title of the VALID orcid to test what happens when the orcid starts with "http://orcid.org"
    -- Enter an INVALID orcid value such as aaaa-bbbb-cccc-dddd or 1111=2222=3333=4444-5555 
    -- Enter NO orcid value
-  As userA you can look at your submitted etds, manage datastreams, compare MODS results.
     -- Look at the &lt;mods:name element for the valid orcid
     -- Look at the &lt;mods:name element for the invalid orcid
     -- Look at the &lt;mods:name element for the empty orcid




# Additional Notes:
* This change requires no documentation to be updated.
* This change adds no new dependencies 
* This change requires no other modifications to be made to the repository.
* This change should not impact execution of existing code.

# Interested parties
@CanOfBees @DonRichards @robert-patrick-waltz 