### PR TITLE
Create post-process transform per DIT-1130.

### DIFF
--- a/post_process_transforms/digital_collections_post_process.xsl
+++ b/post_process_transforms/digital_collections_post_process.xsl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                exclude-result-prefixes="xs"
+                version="1.0">
+
+  <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="*[not(node())]"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()[normalize-space()]|@*[normalize-space()]"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>
+


### PR DESCRIPTION
**JIRA Ticket**: [DIT-1130](https://jira.lib.utk.edu/browse/DIT-1130)

# What does this Pull Request do?

Creates a post-process transform for digital collections.

# What's new?
Currently, the default Islandora form for digital collections has no associated post-process transform.  This leads to blank nodes being maintained and Solr transforms generating bad values in the Solr document that get returned to the Web UI.

# How should this be tested?

1. Use islandora_vagrant
2. Associate this post-process with the default collections form.
3. Create a record.
4. Check the MODS datastream for blank nodes.

# Interested parties
@CanOfBees 